### PR TITLE
fix: fatal error and can't start the server

### DIFF
--- a/app.configs.yml
+++ b/app.configs.yml
@@ -10,4 +10,3 @@ db.config:
   host: localhost
   port: 3306
   database: test_ent
-

--- a/app.configs.yml
+++ b/app.configs.yml
@@ -4,7 +4,7 @@ application:
   cors:
     allowedHost: localhost, https://labstack.com, https://labstack.net
 
-db.config:
+db.configs:
   username: root
   password: MyRoot!23
   host: localhost


### PR DESCRIPTION
![image](https://github.com/adityasatrio/golang-echo-boilerplate/assets/10755895/03e25446-5eeb-401b-863e-c71b5f4922ac)

The file [`configuration_env.go#L13`](https://github.com/adityasatrio/golang-echo-boilerplate/blob/master/configs/configuration_env.go#L13) is attempting to read the configuration from the file `app.configs.yml`, but currently, the file is still named `app.config.yml`. This causes a fatal error, and the server cannot be started.

Renaming the yml file should fix the issue.

Related commit: 631bffe63cd0cc30969c01ca444767fb8cbc8ff4