### PR TITLE
Add MySQL/PostgreSQL driver switch and seeder/migration GitHub Actions

### DIFF
--- a/.env
+++ b/.env
@@ -33,6 +33,11 @@ db.configs.database = "test_ent"
 db.configs.maxIdleConn = 10
 db.configs.maxOpenConn = 100
 
+## db.configs.driver: "mysql" or "postgres"
+db.configs.driver = "mysql"
+## sslmode only applies when db.configs.driver = "postgres" (disable|require|verify-ca|verify-full)
+db.configs.sslmode = "disable"
+
 cache.configs.redis.db = 0
 cache.configs.redis.poolSize = 10
 cache.configs.redis.isTls = true

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -1,0 +1,92 @@
+name: DB Migration
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Migration command to run"
+        required: true
+        type: choice
+        default: status
+        options:
+          - up
+          - up-to
+          - down
+          - down-to
+          - redo
+          - status
+      version:
+        description: "Migration version (required for up-to / down-to, e.g. 20260630120004)"
+        required: false
+        type: string
+      db_driver:
+        description: "Target database driver"
+        required: true
+        type: choice
+        default: mysql
+        options:
+          - mysql
+          - postgres
+      target_environment:
+        description: "GitHub Environment holding the DB connection secrets"
+        required: true
+        type: choice
+        default: development
+        options:
+          - development
+          - staging
+          - production
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    name: Run migration
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.target_environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+          cache-dependency-path: ./go.sum
+
+      - name: Validate version input
+        if: inputs.action == 'up-to' || inputs.action == 'down-to'
+        run: |
+          if [ -z "${{ inputs.version }}" ]; then
+            echo "::error::'version' input is required for action '${{ inputs.action }}'"
+            exit 1
+          fi
+
+      - name: Write DB connection config
+        env:
+          DB_HOST: ${{ secrets.DB_HOST }}
+          DB_PORT: ${{ secrets.DB_PORT }}
+          DB_USERNAME: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          DB_NAME: ${{ secrets.DB_NAME }}
+          DB_SSLMODE: ${{ secrets.DB_SSLMODE }}
+        run: |
+          {
+            echo "db.configs.username = \"$DB_USERNAME\""
+            echo "db.configs.password = \"$DB_PASSWORD\""
+            echo "db.configs.host = \"$DB_HOST\""
+            echo "db.configs.port = \"$DB_PORT\""
+            echo "db.configs.database = \"$DB_NAME\""
+            echo "db.configs.sslmode = \"${DB_SSLMODE:-disable}\""
+          } >> .env
+
+      - name: Build migration binary
+        run: go build -v -o migration migrations/cmd/main.go
+
+      - name: Run migration
+        run: |
+          if [ "${{ inputs.action }}" = "up-to" ] || [ "${{ inputs.action }}" = "down-to" ]; then
+            ./migration ${{ inputs.db_driver }} ${{ inputs.action }} ${{ inputs.version }}
+          else
+            ./migration ${{ inputs.db_driver }} ${{ inputs.action }}
+          fi

--- a/.github/workflows/seeder.yml
+++ b/.github/workflows/seeder.yml
@@ -1,0 +1,105 @@
+name: DB Seeder
+
+on:
+  workflow_dispatch:
+    inputs:
+      seeder_file:
+        description: "Seeder SQL file under seeders/ to run, or 'all' to run every file in order"
+        required: true
+        type: choice
+        default: all
+        options:
+          - all
+          - 0001_seed_default_roles.sql
+          - 0002_seed_admin_user.sql
+      db_driver:
+        description: "Target database driver"
+        required: true
+        type: choice
+        default: mysql
+        options:
+          - mysql
+          - postgres
+      target_environment:
+        description: "GitHub Environment holding the DB connection secrets"
+        required: true
+        type: choice
+        default: development
+        options:
+          - development
+          - staging
+          - production
+
+permissions:
+  contents: read
+
+jobs:
+  seed:
+    name: Run seeder
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.target_environment }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve seeder file list
+        id: files
+        run: |
+          if [ "${{ inputs.seeder_file }}" = "all" ]; then
+            files=$(find seeders -maxdepth 1 -name '*.sql' | sort)
+          else
+            file="seeders/${{ inputs.seeder_file }}"
+            if [ ! -f "$file" ]; then
+              echo "::error::Seeder file not found: $file"
+              exit 1
+            fi
+            files="$file"
+          fi
+
+          if [ -z "$files" ]; then
+            echo "::error::No seeder files found to run"
+            exit 1
+          fi
+
+          {
+            echo "list<<EOF"
+            echo "$files"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install MySQL client
+        if: inputs.db_driver == 'mysql'
+        run: sudo apt-get update && sudo apt-get install -y mysql-client
+
+      - name: Install PostgreSQL client
+        if: inputs.db_driver == 'postgres'
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+
+      - name: Run seeder(s) against MySQL
+        if: inputs.db_driver == 'mysql'
+        env:
+          DB_HOST: ${{ secrets.DB_HOST }}
+          DB_PORT: ${{ secrets.DB_PORT }}
+          DB_USER: ${{ secrets.DB_USERNAME }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          DB_NAME: ${{ secrets.DB_NAME }}
+        run: |
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            echo "Running $file"
+            mysql --host="$DB_HOST" --port="$DB_PORT" --user="$DB_USER" --password="$DB_PASSWORD" "$DB_NAME" < "$file"
+          done <<< "${{ steps.files.outputs.list }}"
+
+      - name: Run seeder(s) against PostgreSQL
+        if: inputs.db_driver == 'postgres'
+        env:
+          PGHOST: ${{ secrets.DB_HOST }}
+          PGPORT: ${{ secrets.DB_PORT }}
+          PGUSER: ${{ secrets.DB_USERNAME }}
+          PGPASSWORD: ${{ secrets.DB_PASSWORD }}
+          PGDATABASE: ${{ secrets.DB_NAME }}
+        run: |
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            echo "Running $file"
+            psql -v ON_ERROR_STOP=1 -f "$file"
+          done <<< "${{ steps.files.outputs.list }}"

--- a/Makefile
+++ b/Makefile
@@ -83,23 +83,26 @@ clean: confirm
 	sleep 5
 	rm -rf ./mocks/*
 
+# DB driver used by the migration/seeder tooling: mysql or postgres
+DRIVER ?= mysql
+
 migration-build:
 	@echo "Warning this action will build unix executable file "
 	go build -v -o migration migrations/cmd/main.go
 
 migration-create:
-	./migration mysql create $(name) $(type)
+	./migration $(DRIVER) create $(name) $(type)
 
 migration-up:
 	go build -v -o migration migrations/cmd/main.go
-	 ./migration mysql up
+	 ./migration $(DRIVER) up
 
 migration-down:
 	go build -v -o migration migrations/cmd/main.go
-	./migration mysql down
+	./migration $(DRIVER) down
 
 migration-status:
-	./migration mysql status
+	./migration $(DRIVER) status
 
 # Linting
 lint:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Boilerplate template for backend project using go language for optimize and effi
   - [Dependency Injection](#dependency-injection)
   - [OpenAPI Docs and Swagger](#openapi-docs-and-swagger)
   - [Migration](#migration)
+  - [Switching database driver (MySQL / PostgreSQL)](#switching-database-driver)
+  - [Seeders](#seeders)
   - [Running with config](#run-config)
 - [Example code](#example-code)
 - [Build project](#build-project)
@@ -110,6 +112,30 @@ make migration-down
 ```shell
 make migration-status
 ```
+6. All `migration-*` targets default to the `mysql` driver. Override with `DRIVER=postgres` to target PostgreSQL instead:
+```shell
+make migration-up DRIVER=postgres
+```
+7. Migrations can also be run/rolled back from GitHub Actions via the **DB Migration** workflow (`.github/workflows/migration.yml`, `workflow_dispatch`). Pick the action (`up`, `up-to`, `down`, `down-to`, `redo`, `status`), the `db_driver`, and the target GitHub Environment holding the `DB_HOST` / `DB_PORT` / `DB_USERNAME` / `DB_PASSWORD` / `DB_NAME` secrets.
+
+> Note: the bundled migration files under `migrations/` are written with MySQL-specific DDL (`AUTO_INCREMENT`, `bigint unsigned`, `tinyint(1)`, `datetime`). When targeting PostgreSQL for the first time, add Postgres-compatible migration files (or port the existing ones) before running `up`.
+
+### Switching database driver
+
+The ent client (`configs/database/connection_sqlent.go`, `connection_ent.go`) and the migration runner build their DSN from `configs/database/dsn.go`, which reads:
+- `db.configs.driver` (`.env`) - `mysql` (default) or `postgres`
+- `db.configs.username` / `db.configs.password` / `db.configs.host` / `db.configs.port` / `db.configs.database` (`secret.env`)
+- `db.configs.sslmode` (`.env`, PostgreSQL only) - defaults to `disable`
+
+To switch the running application to PostgreSQL, set `db.configs.driver = "postgres"` in `.env` (and adjust credentials in `secret.env`). No code changes are required.
+
+### Seeders
+Plain, idempotent `.sql` files under `seeders/` (numbered, e.g. `0001_seed_default_roles.sql`) that can be re-run safely - each statement guards itself with `WHERE NOT EXISTS (...)`. Run them via the **DB Seeder** GitHub Actions workflow (`.github/workflows/seeder.yml`, `workflow_dispatch`):
+- `seeder_file`: pick a specific file under `seeders/`, or `all` to run every file in order
+- `db_driver`: `mysql` or `postgres`
+- `target_environment`: the GitHub Environment holding the `DB_HOST` / `DB_PORT` / `DB_USERNAME` / `DB_PASSWORD` / `DB_NAME` secrets
+
+When adding a new seeder file, also add it to the `seeder_file` choice list in `.github/workflows/seeder.yml`.
 
 ### Run config
 - Default general config is located in `root-project-path/.env`

--- a/README.md
+++ b/README.md
@@ -137,10 +137,44 @@ Plain, idempotent `.sql` files under `seeders/` (numbered, e.g. `0001_seed_defau
 
 When adding a new seeder file, also add it to the `seeder_file` choice list in `.github/workflows/seeder.yml`.
 
+### GitHub Secrets required for the Seeder / Migration workflows
+Both `.github/workflows/seeder.yml` and `.github/workflows/migration.yml` run against a real database, so they read connection details from secrets rather than the committed `.env`/`secret.env` files. Add these under **Settings → Environments** for each environment named in the `target_environment` input (`development`, `staging`, `production`), or as repository-level secrets if you don't use GitHub Environments:
+
+| Secret          | Required | Notes                                                              |
+|-----------------|----------|----------------------------------------------------------------------|
+| `DB_HOST`       | Yes      | Database host reachable from GitHub-hosted runners                  |
+| `DB_PORT`       | Yes      | `3306` for MySQL, `5432` for PostgreSQL                             |
+| `DB_USERNAME`   | Yes      | Connects with permission to run DDL (migration) / DML (seeder)      |
+| `DB_PASSWORD`   | Yes      |                                                                       |
+| `DB_NAME`       | Yes      |                                                                       |
+| `DB_SSLMODE`    | No       | Migration workflow only; PostgreSQL only. Defaults to `disable`     |
+
+The `db_driver` workflow input (`mysql` or `postgres`) controls which client/DSN format is used; it does not need its own secret.
+
 ### Run config
 - Default general config is located in `root-project-path/.env`
 - For credential the default config is located in `root-project-path/secret.env`
   - We can use custom path on running the executable application `./main -credentials-path="ABC" -credentials-name="XYZ"`
+
+#### Environment / config variables required to run the application
+The app does **not** read OS environment variables directly - configuration is loaded from the two files above. Both files are committed with working local-dev defaults; edit the ones below before running outside local dev:
+
+| Key (`.env` / `secret.env`)                                        | File         | Required | Default in repo                  |
+|----------------------------------------------------------------------|--------------|----------|-----------------------------------|
+| `db.configs.driver`                                                   | `.env`       | No       | `mysql` (or `postgres`)           |
+| `db.configs.database`                                                 | `.env`       | Yes      | `test_ent`                        |
+| `db.configs.sslmode`                                                  | `.env`       | No       | `disable` (PostgreSQL only)       |
+| `db.configs.maxIdleConn` / `db.configs.maxOpenConn`                   | `.env`       | No       | `10` / `100`                      |
+| `db.configs.username` / `db.configs.password`                         | `secret.env` | Yes      | `root` / `root`                   |
+| `db.configs.host` / `db.configs.port`                                  | `secret.env` | Yes      | `localhost` / `3306`              |
+| `cache.configs.redis.host` / `port` / `username` / `password`          | `secret.env` | Yes (if using cache) | `localhost` / `6379` / `""` / `""` |
+| `rabbitmq.configs.username` / `password` / `host` / `port`             | `secret.env` | Yes (if `rabbitmq.configs.enable = true`) | `guest` / `guest` / `localhost` / `5672` |
+| `auth0.domain` / `auth0.clientId` / `auth0.audience` / `auth0.callbackUrl` | `.env`   | Yes (if using Auth0) | `CHANGEME_*` placeholders - replace with your Auth0 tenant |
+| `auth0.clientSecret`                                                   | `secret.env` | Yes (if using Auth0) | `CHANGEME_AUTH0_CLIENT_SECRET` placeholder |
+| `jwt.secret`                                                           | `secret.env` | Yes      | `CHANGEME_JWT_SECRET_REPLACE_WITH_RANDOM_VALUE` placeholder - rotate before production use |
+| `jwt.expiryMinutes`                                                    | `.env`       | No       | `60`                              |
+
+Everything else in `.env` (`application.*`, `swagger.*`, `ratelimit.*`, `cache.ttl.*`, `rabbitmq.example.*`) has a working default and only needs changing if you want different behavior.
 
 
 ## Build project

--- a/configs/database/connection_ent.go
+++ b/configs/database/connection_ent.go
@@ -2,13 +2,12 @@ package database
 
 import (
 	"context"
-	"fmt"
 	"github.com/labstack/gommon/log"
-	"myapp/configs/credential"
 	"myapp/ent"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
 )
 
 // NewEntClient use if not wrap sql db
@@ -16,16 +15,11 @@ import (
 //goland:noinspection GoUnusedExportedFunction
 func NewEntClient() *ent.Client {
 
-	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true",
-		credential.GetString("db.configs.username"),
-		credential.GetString("db.configs.password"),
-		credential.GetString("db.configs.host"),
-		credential.GetString("db.configs.port"),
-		credential.GetString("db.configs.database"))
+	driverName, dsn := BuildDSN()
 
-	log.Debugf("DSN ", dsn)
+	log.Debugf("DB driver=", driverName)
 
-	client, err := ent.Open("mysql", dsn, ent.Debug(), ent.Log(func(i ...interface{}) {
+	client, err := ent.Open(driverName, dsn, ent.Debug(), ent.Log(func(i ...interface{}) {
 		for _, v := range i {
 			log.Debugf(time.Now().Format("2006-01-02 15:04:05"), v)
 		}

--- a/configs/database/connection_sqlent.go
+++ b/configs/database/connection_sqlent.go
@@ -3,27 +3,22 @@ package database
 import (
 	"database/sql"
 	entSql "entgo.io/ent/dialect/sql"
-	"fmt"
 	"github.com/labstack/gommon/log"
 	"myapp/configs/credential"
 	"myapp/ent"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
 )
 
 func NewSqlEntClient() *ent.Client {
 
-	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true",
-		credential.GetString("db.configs.username"),
-		credential.GetString("db.configs.password"),
-		credential.GetString("db.configs.host"),
-		credential.GetString("db.configs.port"),
-		credential.GetString("db.configs.database"))
+	driverName, dsn := BuildDSN()
 
-	log.Debug("DSN=", dsn) // for debug only
+	log.Debug("DB driver=", driverName) // for debug only
 
-	db, err := sql.Open("mysql", dsn)
+	db, err := sql.Open(driverName, dsn)
 	if err != nil {
 		log.Fatalf("failed opening connection to DB: %v", err)
 	}
@@ -32,7 +27,7 @@ func NewSqlEntClient() *ent.Client {
 	db.SetMaxOpenConns(credential.GetInt("db.configs.maxOpenConn"))
 	db.SetConnMaxLifetime(time.Hour)
 
-	drv := entSql.OpenDB("mysql", db)
+	drv := entSql.OpenDB(driverName, db)
 
 	var client *ent.Client
 	appMode := credential.GetString("application.mode")

--- a/configs/database/dsn.go
+++ b/configs/database/dsn.go
@@ -1,0 +1,60 @@
+package database
+
+import (
+	"fmt"
+
+	"entgo.io/ent/dialect"
+	"myapp/configs/credential"
+)
+
+// SupportedDriver is a database driver supported by the ent client setup.
+type SupportedDriver string
+
+const (
+	DriverMySQL    SupportedDriver = "mysql"
+	DriverPostgres SupportedDriver = "postgres"
+)
+
+// ResolveDriver reads db.configs.driver and normalizes it to a SupportedDriver,
+// defaulting to mysql when unset to preserve existing behavior.
+func ResolveDriver() SupportedDriver {
+	driver := credential.GetString("db.configs.driver")
+
+	switch SupportedDriver(driver) {
+	case DriverPostgres:
+		return DriverPostgres
+	case DriverMySQL, "":
+		return DriverMySQL
+	default:
+		return DriverMySQL
+	}
+}
+
+// BuildDSN returns the sql.Open/ent driver name (e.g. "mysql", "postgres")
+// alongside the connection string for the currently configured db.configs.driver.
+func BuildDSN() (driverName string, dsn string) {
+	return buildDSN(ResolveDriver())
+}
+
+func buildDSN(driver SupportedDriver) (string, string) {
+	username := credential.GetString("db.configs.username")
+	password := credential.GetString("db.configs.password")
+	host := credential.GetString("db.configs.host")
+	port := credential.GetString("db.configs.port")
+	database := credential.GetString("db.configs.database")
+
+	switch driver {
+	case DriverPostgres:
+		sslMode := credential.GetString("db.configs.sslmode")
+		if sslMode == "" {
+			sslMode = "disable"
+		}
+		dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+			host, port, username, password, database, sslMode)
+		return dialect.Postgres, dsn
+	default:
+		dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true",
+			username, password, host, port, database)
+		return dialect.MySQL, dsn
+	}
+}

--- a/configs/database/dsn.go
+++ b/configs/database/dsn.go
@@ -52,6 +52,8 @@ func buildDSN(driver SupportedDriver) (string, string) {
 		dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
 			host, port, username, password, database, sslMode)
 		return dialect.Postgres, dsn
+	case DriverMySQL:
+		fallthrough
 	default:
 		dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true",
 			username, password, host, port, database)

--- a/migrations/cmd/main.go
+++ b/migrations/cmd/main.go
@@ -62,7 +62,7 @@ func main() {
 		log.Fatalf("%q driver not supported\n", driver)
 	}
 
-	dbSource := migrations.MigrationConnection()
+	dbSource := migrations.MigrationConnection(driver)
 	db, err := sql.Open(driver, dbSource)
 	if err != nil {
 		log.Fatalf("-dbstring=%q: %v\n", dbSource, err)

--- a/migrations/cmd/main.go
+++ b/migrations/cmd/main.go
@@ -62,10 +62,10 @@ func main() {
 		log.Fatalf("%q driver not supported\n", driver)
 	}
 
-	dbSource := migrations.MigrationConnection(driver)
+	dbSource, dbSourceRedacted := migrations.MigrationConnection(driver)
 	db, err := sql.Open(driver, dbSource)
 	if err != nil {
-		log.Fatalf("-dbstring=%q: %v\n", dbSource, err)
+		log.Fatalf("-dbstring=%q: %v\n", dbSourceRedacted, err)
 	}
 
 	executeCommand(args, command, db)

--- a/migrations/schema_migration.go
+++ b/migrations/schema_migration.go
@@ -11,7 +11,9 @@ const (
 	fileConfigType = ".env"
 )
 
-func MigrationConnection() string {
+// MigrationConnection builds the connection string for the given goose
+// driver ("mysql", "postgres" or "sqlite3"), reading credentials from .env.
+func MigrationConnection(driver string) string {
 	viper.SetConfigFile(fileConfigType)
 	viper.AutomaticEnv()
 
@@ -25,13 +27,23 @@ func MigrationConnection() string {
 		log.Println("Config file changed:", e.Name)
 	})
 
-	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true",
-		viper.GetString("db.configs.username"),
-		viper.GetString("db.configs.password"),
-		viper.GetString("db.configs.host"),
-		viper.GetString("db.configs.port"),
-		viper.GetString("db.configs.database"))
-	return dsn
+	username := viper.GetString("db.configs.username")
+	password := viper.GetString("db.configs.password")
+	host := viper.GetString("db.configs.host")
+	port := viper.GetString("db.configs.port")
+	database := viper.GetString("db.configs.database")
+
+	if driver == "postgres" {
+		sslMode := viper.GetString("db.configs.sslmode")
+		if sslMode == "" {
+			sslMode = "disable"
+		}
+		return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+			host, port, username, password, database, sslMode)
+	}
+
+	return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true",
+		username, password, host, port, database)
 }
 
 func MigrationPath() string {

--- a/migrations/schema_migration.go
+++ b/migrations/schema_migration.go
@@ -13,7 +13,9 @@ const (
 
 // MigrationConnection builds the connection string for the given goose
 // driver ("mysql", "postgres" or "sqlite3"), reading credentials from .env.
-func MigrationConnection(driver string) string {
+// It returns the connection string to open the DB with, plus a redacted
+// copy (password masked) safe to print in logs/errors.
+func MigrationConnection(driver string) (dsn string, redacted string) {
 	viper.SetConfigFile(fileConfigType)
 	viper.AutomaticEnv()
 
@@ -33,17 +35,25 @@ func MigrationConnection(driver string) string {
 	port := viper.GetString("db.configs.port")
 	database := viper.GetString("db.configs.database")
 
+	const masked = "****"
+
 	if driver == "postgres" {
 		sslMode := viper.GetString("db.configs.sslmode")
 		if sslMode == "" {
 			sslMode = "disable"
 		}
-		return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		dsn = fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
 			host, port, username, password, database, sslMode)
+		redacted = fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+			host, port, username, masked, database, sslMode)
+		return dsn, redacted
 	}
 
-	return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true",
+	dsn = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true",
 		username, password, host, port, database)
+	redacted = fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true",
+		username, masked, host, port, database)
+	return dsn, redacted
 }
 
 func MigrationPath() string {

--- a/seeders/0001_seed_default_roles.sql
+++ b/seeders/0001_seed_default_roles.sql
@@ -1,0 +1,12 @@
+-- Seed default roles (Admin, User).
+-- Idempotent: safe to run multiple times against either MySQL or PostgreSQL
+-- (the active db.configs.driver). Run after migrations have created the
+-- `roles` table.
+
+INSERT INTO roles (versions, created_by, created_at, updated_at, name, text)
+SELECT 1, 'system', NOW(), NOW(), 'Admin', 'Full access to all pages and resources'
+WHERE NOT EXISTS (SELECT 1 FROM roles WHERE name = 'Admin');
+
+INSERT INTO roles (versions, created_by, created_at, updated_at, name, text)
+SELECT 1, 'system', NOW(), NOW(), 'User', 'Read-only access to system parameters'
+WHERE NOT EXISTS (SELECT 1 FROM roles WHERE name = 'User');

--- a/seeders/0002_seed_admin_user.sql
+++ b/seeders/0002_seed_admin_user.sql
@@ -1,0 +1,21 @@
+-- Seed a bootstrap admin user with the Admin role.
+-- Idempotent: safe to run multiple times against either MySQL or PostgreSQL
+-- (the active db.configs.driver). Requires 0001_seed_default_roles.sql to
+-- have run first.
+--
+-- Login: admin@example.com / ChangeMe123!
+-- Rotate this password immediately in any non-local environment.
+
+INSERT INTO users (versions, created_by, created_at, updated_at, name, password, avatar, role_id, is_verified, email)
+SELECT 1, 'system', NOW(), NOW(), 'Admin',
+       '$2a$10$kJ693kpseUIVbBUsoOL/juX/Qn//aaKaM3aWtWXxeyjCL.JdzXVIS',
+       '', (SELECT id FROM roles WHERE name = 'Admin'), 1, 'admin@example.com'
+WHERE NOT EXISTS (SELECT 1 FROM users WHERE email = 'admin@example.com');
+
+INSERT INTO role_users (versions, created_by, created_at, updated_at, user_id, role_id)
+SELECT 1, 'system', NOW(), NOW(), u.id, r.id
+FROM users u, roles r
+WHERE u.email = 'admin@example.com' AND r.name = 'Admin'
+  AND NOT EXISTS (
+    SELECT 1 FROM role_users ru WHERE ru.user_id = u.id AND ru.role_id = r.id
+  );


### PR DESCRIPTION
- Extract DSN building into configs/database/dsn.go, driven by the new
  db.configs.driver (.env) key, and wire it into the ent client setup
  (connection_sqlent.go, connection_ent.go) and the goose migration
  runner (migrations/schema_migration.go) so both can target MySQL or
  PostgreSQL without code changes.
- Add Makefile DRIVER variable for migration-* targets.
- Add seeders/ with idempotent, cross-dialect seed SQL files.
- Add .github/workflows/seeder.yml (workflow_dispatch: pick a seeder
  file or "all", driver, and target environment).
- Add .github/workflows/migration.yml (workflow_dispatch: up/up-to/
  down/down-to/redo/status, driver, and target environment).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Cbstsxsa1VhGcF6bGcUytT